### PR TITLE
Update .openpublishing.publish.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -47,12 +47,14 @@
   "targets": {
     "pdf": {
       "template_folder": "_themes.pdf"
-    },
-    "Pdf": {
-      "template_folder": "_themes.pdf"
     }
   },
   "docs_build_engine": {
     "name": "docfx_v3"
+  },
+  "targets": {
+    "Pdf": {
+      "template_folder": "_themes.pdf"
+    }
   }
 }


### PR DESCRIPTION
Having two "pdf" in a targets results in build and publish error for localized articles.